### PR TITLE
support libchewing-v0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,15 +499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cdb2"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d174c2b231d61e0f8f325e51fceb187d6bcbc53d25dad6607afee7a452f5482"
-dependencies = [
- "memmap2 0.9.4",
-]
-
-[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,15 +524,13 @@ checksum = "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f"
 
 [[package]]
 name = "chewing"
-version = "0.6.0-alpha.2"
-source = "git+https://github.com/chewing/libchewing.git#b02653347ad29b0dc7f67fe6a3efefa6307f9981"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770e41c968a02cebfcb6baf2bf520c22c14d4901c5bcf064967b6da931c140d7"
 dependencies = [
- "bytemuck",
- "cdb2",
+ "der",
  "directories",
- "riff",
- "thiserror",
- "tracing",
+ "log",
 ]
 
 [[package]]
@@ -762,6 +751,15 @@ name = "cursor-icon"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "derivative"
@@ -1668,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "malloc_buf"
@@ -2279,12 +2277,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "riff"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c601484456988d75017d86700d3743b949c21cdc7399f940c75e34680d185c5"
 
 [[package]]
 name = "roxmltree"
@@ -3700,6 +3692,12 @@ dependencies = [
  "quote",
  "syn 2.0.48",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ iced_core = { git = "https://github.com/rano-oss/iced", branch = "input_method_a
 iced_renderer = { git = "https://github.com/rano-oss/iced", branch = "input_method_and_virtual_keyboard" }
 iced_runtime = { git = "https://github.com/rano-oss/iced", branch = "input_method_and_virtual_keyboard" }
 env_logger = "0.10"
-chewing = { git = "https://github.com/chewing/libchewing.git" }
+chewing = "0.9"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Hi @rano-oss,

This patch is based on your branch https://github.com/rano-oss/chewingwl/tree/feature/settings

It is to solve some API breakage. (libchewing v0.6 -> libchewing v0.9)