### PR TITLE
add github action as ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+env: 
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          # - beta
+          # - nightly
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt update && sudo apt install -y libchewing libxkbcommon-dev
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo build --verbose
+      - run: cargo test --verbose


### PR DESCRIPTION
- Added a GitHub Actions workflow for continuous integration (CI).
- Includes the actions/checkout@v4 step to check out the repository's code as part of the workflow.

This will help automate the CI process and ensure code is properly tested with each commit or pull request.


example:
https://github.com/shawn111/chewingwl/actions/runs/12445718830